### PR TITLE
automatically generate ros_lib

### DIFF
--- a/firmware/atom_s3_rosserial_message_display/extra_script.py
+++ b/firmware/atom_s3_rosserial_message_display/extra_script.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+
+def run_subprocess(cmd, working_directory="."):
+    if sys.version.split(".")[0] == "2":
+        subprocess.call(cmd, shell=True, cwd=working_directory)
+    if sys.version.split(".")[0] == "3":
+        subprocess.run(cmd, shell=True, cwd=working_directory)
+
+def get_lib_dir():
+    current_dir = os.getcwd()
+    parent_dir = os.path.dirname(current_dir)
+    lib_dir = os.path.join(parent_dir, 'lib')
+    return lib_dir
+
+def generate_roslib():
+    run_subprocess("rosrun rosserial_arduino make_libraries.py .", working_directory=get_lib_dir())
+
+generate_roslib()

--- a/firmware/atom_s3_rosserial_message_display/platformio.ini
+++ b/firmware/atom_s3_rosserial_message_display/platformio.ini
@@ -14,3 +14,4 @@ build_flags =
 	-DARDUINO_USB_CDC_ON_BOOT=1
 	-DARDUINO_USB_MODE=1
 
+extra_scripts = pre:extra_script.py


### PR DESCRIPTION
using extra_scripts in platformio, `ros_lib` is generated automatically. 
However, library is generated every time resulting whole build is necessary.